### PR TITLE
Exclude CMakeLists.txt from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *
 !*.hpp
 !*.cpp
+!CMakeLists.txt


### PR DESCRIPTION
If CMakeLists.txt is included in .gitignore (as it is here via `*`), Visual Studio will fail to detect the project in a quite confusing way.
While this is probably a Visual Studio bug and the project is not even using CMake right now, it wouldn't do any harm to include this exception.